### PR TITLE
fix(make): Add support for parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,21 @@ ifdef GBDK_DEBUG
 	LCCFLAGS += -debug -v
 endif
 
+# Detect the number of CPU cores
+ifeq ($(OS),Windows_NT)
+	JOBS := $(NUMBER_OF_PROCESSORS)
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		JOBS := $(shell nproc)
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		JOBS := $(shell sysctl -n hw.ncpu)
+	endif
+endif
+
+# Use parallel execution by default, using the number of detected cores
+MAKEFLAGS += --jobs=$(JOBS)
 
 # You can set the name of the .gbc ROM file here
 PROJECTNAME    = pocket_aquarium


### PR DESCRIPTION
This commit adds support for multiple concurrent builds, defaulting to the system core count. This significantly speeds up compilation.