### PR TITLE
chore(build): Add initial support for compilation database generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 obj/
 gdk/
+.cache
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,14 @@ else()
   set(GBDK_HOME $ENV{GBDK_HOME})
 endif()
 
+get_filename_component(GBDK_HOME "${GBDK_HOME}" ABSOLUTE)
+
 # Find the LCC compiler
 find_program(LCC "${GBDK_HOME}/bin/lcc" REQUIRED)
 
 # Set compiler and linker flags
 set(CMAKE_C_COMPILER ${LCC})
-set(CMAKE_C_FLAGS "-Wm-yC")
+set(CMAKE_C_FLAGS "-Wm-yC -I\"${GBDK_HOME}/include\" -msm83 -D__PORT_sm83 -D__TARGET_GB -D__SDCC")
 
 # Add debug flags if GBDK_DEBUG is set
 option(GBDK_DEBUG "Enable GBDK debug mode" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.20)
+project(pocket_aquarium C)
+
+# Set the GBDK home directory
+if(NOT DEFINED ENV{GBDK_HOME})
+  set(GBDK_HOME "./gbdk")
+else()
+  set(GBDK_HOME $ENV{GBDK_HOME})
+endif()
+
+# Find the LCC compiler
+find_program(LCC "${GBDK_HOME}/bin/lcc" REQUIRED)
+
+# Set compiler and linker flags
+set(CMAKE_C_COMPILER ${LCC})
+set(CMAKE_C_FLAGS "-Wm-yC")
+
+# Add debug flags if GBDK_DEBUG is set
+option(GBDK_DEBUG "Enable GBDK debug mode" OFF)
+if(GBDK_DEBUG)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -debug -v")
+endif()
+
+# Set directories
+set(SRC_DIR "${CMAKE_SOURCE_DIR}/src")
+set(RES_DIR "${CMAKE_SOURCE_DIR}/res")
+set(OBJ_DIR "${CMAKE_BINARY_DIR}/obj")
+
+# Find all source files
+file(GLOB_RECURSE SOURCES
+    "${SRC_DIR}/*.c"
+    "${SRC_DIR}/*.s"
+    "${RES_DIR}/*.c"
+)
+
+# Set output file name
+set(OUTPUT_NAME "${PROJECT_NAME}.gbc")
+
+# Create the executable
+add_executable(${PROJECT_NAME} ${SOURCES})
+
+# Set the output directory for the final .gbc file
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${OBJ_DIR}"
+    OUTPUT_NAME "${OUTPUT_NAME}"
+)
+
+# Generate compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Custom command to copy compile_commands.json to the project root
+add_custom_command(
+    TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_BINARY_DIR}/compile_commands.json
+            ${CMAKE_SOURCE_DIR}/compile_commands.json
+)

--- a/Readme.md
+++ b/Readme.md
@@ -20,3 +20,14 @@ To build the project, you need to have the GBDK (Game Boy Development Kit) insta
 ```sh
 make
 ```
+
+### Using cmake
+
+Using cmake provides a more flexible way to build the project. You can use cmake to generate a Makefile or other build systems. Out of the box there is support for compilation databases for clang and Visual Studio.
+
+To build the project using cmake, follow these steps:
+
+```sh
+cmake -S . -B build
+```
+


### PR DESCRIPTION
This adds cmake as an optional build script. This will also generate a compilation database to the build directory for use with an LSP.